### PR TITLE
Changed from bool to string for empty responses

### DIFF
--- a/pkgparse/registry/base.py
+++ b/pkgparse/registry/base.py
@@ -139,44 +139,44 @@ class BaseRegistry:
         if 'name' in response:
             package['name'] = response['name']
         else:
-            package['name'] = False
+            package['name'] = ""
 
         if 'description' in response:
             package['description'] = response['description']
         else:
-            package['description'] = False
+            package['description'] = ""
 
         if 'license' in response:
             package['license'] = response['license']
         else:
-            package['license'] = False
+            package['license'] = ""
 
         if 'source_repo' in response:
             package['source_repo'] = response['source_repo']
         else:
-            package['source_repo'] = False
+            package['source_repo'] = ""
 
         if 'homepage' in response:
             package['homepage'] = response['homepage']
         else:
-            package['homepage'] = False
+            package['homepage'] = ""
 
         if 'package_page' in response:
             package['package_page'] = response['package_page']
         elif self.pkg_page:
             package['package_page'] = self.pkg_page.format(response['name'])
         else:
-            package['package_page'] = False
+            package['package_page'] = ""
 
         if 'tarball' in response:
             package['tarball'] = response['tarball']
         else:
-            package['tarball'] = False
+            package['tarball'] = ""
 
         if 'latest_version' in response:
             package['latest_version'] = response['latest_version']
         else:
-            package['latest_version'] = False
+            package['latest_version'] = ""
 
         return package
 

--- a/tests/integration/test_npm_registry_endpoints.py
+++ b/tests/integration/test_npm_registry_endpoints.py
@@ -26,7 +26,7 @@ class NPMRegistryIntegrationTestCase(unittest.TestCase):
                            "modules",
             "license": "MIT",
             "source_repo": "https://github.com/marcus-crane/pkgparse",
-            "homepage": False,
+            "homepage": "",
             "package_page": "https://npmjs.com/package/pkgparse",
             "tarball": "https://registry.npmjs.org/pkgparse/-/"
                        "pkgparse-2.1.1.tgz",

--- a/tests/integration/test_nuget_registry_endpoints.py
+++ b/tests/integration/test_nuget_registry_endpoints.py
@@ -26,7 +26,7 @@ class NugetRegistryIntegrationTestCase(unittest.TestCase):
                             "JSON framework for .NET"),
             "license": ("https://raw.github.com/JamesNK/Newtonsoft.Json"
                         "/master/LICENSE.md"),
-            "source_repo": False,
+            "source_repo": "",
             "homepage": "https://www.newtonsoft.com/json",
             "package_page": "https://www.nuget.org/packages/Newtonsoft.Json/",
             "tarball": ("https://api.nuget.org/v3-flatcontainer/"

--- a/tests/integration/test_pypi_registry_endpoints.py
+++ b/tests/integration/test_pypi_registry_endpoints.py
@@ -24,7 +24,7 @@ class PypiRegistryIntegrationTestCase(unittest.TestCase):
             "name": "requests",
             "description": "Python HTTP for Humans.",
             "license": "Apache 2.0",
-            "source_repo": False,
+            "source_repo": "",
             "homepage": "http://python-requests.org",
             "package_page": "https://pypi.org/project/requests/",
             "tarball": "https://files.pythonhosted.org/packages/b0/e1/"

--- a/tests/integration/test_rubygems_registry_endpoints.py
+++ b/tests/integration/test_rubygems_registry_endpoints.py
@@ -26,7 +26,7 @@ class RubygemsRegistryIntegrationTestCase(unittest.TestCase):
                            "generator.",
             "license": "MIT",
             "source_repo": "https://github.com/jekyll/jekyll",
-            "homepage": False,
+            "homepage": "",
             "package_page": "https://rubygems.org/gems/jekyll",
             "tarball": "https://rubygems.org/gems/jekyll-3.7.3.gem",
             "latest_version": "3.7.3"

--- a/tests/unit/test_base_registry.py
+++ b/tests/unit/test_base_registry.py
@@ -60,7 +60,7 @@ class BaseRegistryUnitTestCase(unittest.TestCase):
                            "modules",
             "license": "MIT",
             "source_repo": "https://github.com/marcus-crane/pkgparse",
-            "homepage": False,
+            "homepage": "",
             "package_page": "https://npmjs.com/package/pkgparse",
             "tarball": "https://registry.npmjs.org/pkgparse/-"
                        "/pkgparse-2.1.1.tgz",
@@ -101,10 +101,10 @@ class BaseRegistryUnitTestCase(unittest.TestCase):
             'name': 'cool_package',
             'description': 'A neat package',
             'license': 'MIT',
-            'source_repo': False,
-            'homepage': False,
-            'package_page': False,
-            'tarball': False,
+            'source_repo': "",
+            'homepage': "",
+            'package_page': "",
+            'tarball': "",
             'latest_version': '2.0.0'
         }
 

--- a/tests/unit/test_npm_registry.py
+++ b/tests/unit/test_npm_registry.py
@@ -22,7 +22,7 @@ class NPMRegistryUnitTestCase(unittest.TestCase):
                            "modules",
             "license": "MIT",
             "source_repo": "https://github.com/marcus-crane/pkgparse",
-            "homepage": False,
+            "homepage": "",
             "package_page": "https://npmjs.com/package/pkgparse",
             "tarball": "https://registry.npmjs.org/pkgparse/-"
                        "/pkgparse-2.1.1.tgz",

--- a/tests/unit/test_nuget_registry.py
+++ b/tests/unit/test_nuget_registry.py
@@ -22,7 +22,7 @@ class NugetRegistryUnitTestCase(unittest.TestCase):
                             "JSON framework for .NET"),
             "license": ("https://raw.github.com/JamesNK/Newtonsoft.Json"
                         "/master/LICENSE.md"),
-            "source_repo": False,
+            "source_repo": "",
             "homepage": "https://www.newtonsoft.com/json",
             "package_page": "https://www.nuget.org/packages/Newtonsoft.Json/",
             "tarball": "https://api.nuget.org/v3-flatcontainer/"

--- a/tests/unit/test_pypi_registry.py
+++ b/tests/unit/test_pypi_registry.py
@@ -20,7 +20,7 @@ class PypiRegistryUnitTestCase(unittest.TestCase):
             "name": "requests",
             "description": "Python HTTP for Humans.",
             "license": "Apache 2.0",
-            "source_repo": False,
+            "source_repo": "",
             "homepage": "http://python-requests.org",
             "package_page": "https://pypi.org/project/requests/",
             "tarball": "https://files.pythonhosted.org/packages/b0/e1/"

--- a/tests/unit/test_rubygems_registry.py
+++ b/tests/unit/test_rubygems_registry.py
@@ -22,7 +22,7 @@ class RubygemsRegistryUnitTestCase(unittest.TestCase):
                            "generator.",
             "license": "MIT",
             "source_repo": "https://github.com/jekyll/jekyll",
-            "homepage": False,
+            "homepage": "",
             "package_page": "https://rubygems.org/gems/jekyll",
             "tarball": "https://rubygems.org/gems/jekyll-3.7.3.gem",
             "latest_version": "3.7.3"


### PR DESCRIPTION
Up until this point, empty keys would return False. That's fine but since the cli I'm writing is in Go, it bitches if the type isn't one or the other.

Sometimes the type would be a bool and sometimes it would be a string.

I've just opted to return an empty string instead. It doesn't really matter anyway. I don't use those fields yet so it's subject to change.